### PR TITLE
Improved the reusability of the middleware by passing all headers ins…

### DIFF
--- a/docs/docs/examples/multiple.md
+++ b/docs/docs/examples/multiple.md
@@ -7,7 +7,7 @@ elegant solution to this. But the current solution is to mount multiple apps ins
 **multiple.py**
 
 ```python
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 import uvicorn
 from fastapi import FastAPI
 from starlette.requests import Request
@@ -16,14 +16,14 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_authorization_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
+def verify_header(headers: Dict) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = ["admin"]  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user
 
 
 users_app = FastAPI()
-users_app.add_middleware(AuthMiddleware, verify_authorization_header=verify_authorization_header)  # Add the middleware with your verification method to the whole application
+users_app.add_middleware(AuthMiddleware, verify_header=verify_header)  # Add the middleware with your verification method to the whole application
 
 
 @users_app.get('/')  # Sample endpoint (secured)

--- a/docs/docs/examples/simple_with_scopes.md
+++ b/docs/docs/examples/simple_with_scopes.md
@@ -1,7 +1,7 @@
 # Basic Example with Scopes
 
 ```python
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 import uvicorn
 from fastapi import FastAPI
 from starlette.authentication import requires
@@ -11,14 +11,14 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_authorization_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
+def verify_header(headers: Dict) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = ["admin"]  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user
 
 
 app = FastAPI()
-app.add_middleware(AuthMiddleware, verify_authorization_header=verify_authorization_header)  # Add the middleware with your verification method to the whole application
+app.add_middleware(AuthMiddleware, verify_header=verify_header)  # Add the middleware with your verification method to the whole application
 
 
 @app.get('/home')  # Sample endpoint (secured)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -38,7 +38,7 @@ from starlette.authentication import BaseUser
 
 ...
 # Takes a string that will look like 'Bearer eyJhbGc...'
-def verify_authorization_header(auth_header: str) -> Tuple[List[str], BaseUser]: # Returns a Tuple of a List of scopes (string) and a BaseUser
+def verify_header(headers: List[str]) -> Tuple[List[str], BaseUser]: # Returns a Tuple of a List of scopes (string) and a BaseUser
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = []  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user
@@ -53,7 +53,7 @@ from fastapi_auth_middleware import AuthMiddleware
 ...
 
 app = FastAPI()
-app.add_middleware(AuthMiddleware, verify_authorization_header=verify_authorization_header)
+app.add_middleware(AuthMiddleware, verify_header=verify_header)
 ```
 
 After adding this middleware, all requests will pass the `verify_authorization_header` function and contain the **scopes** as well as the **user object** as injected dependencies.

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -7,7 +7,7 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
+def verify_header(headers: List[str]) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = []  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -7,14 +7,14 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_authorization_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
+def verify_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = []  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user
 
 
 app = FastAPI()
-app.add_middleware(AuthMiddleware, verify_authorization_header=verify_authorization_header)  # Add the middleware with your verification method to the whole application
+app.add_middleware(AuthMiddleware, verify_header=verify_header)  # Add the middleware with your verification method to the whole application
 
 
 @app.get('/')  # Sample endpoint (secured)

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 import uvicorn
 from fastapi import FastAPI
 from starlette.requests import Request
@@ -7,7 +7,7 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_header(headers: List[str]) -> Tuple[List[str], FastAPIUser]:
+def verify_header(headers: Dict) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = []  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user

--- a/examples/simple_with_scopes.py
+++ b/examples/simple_with_scopes.py
@@ -8,7 +8,7 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
+def verify_header(headers: List[str]) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = ["admin"]  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user

--- a/examples/simple_with_scopes.py
+++ b/examples/simple_with_scopes.py
@@ -8,14 +8,14 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_authorization_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
+def verify_header(auth_header: str) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = ["admin"]  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user
 
 
 app = FastAPI()
-app.add_middleware(AuthMiddleware, verify_authorization_header=verify_authorization_header)  # Add the middleware with your verification method to the whole application
+app.add_middleware(AuthMiddleware, verify_header=verify_header)  # Add the middleware with your verification method to the whole application
 
 
 @app.get('/home')  # Sample endpoint (secured)

--- a/examples/simple_with_scopes.py
+++ b/examples/simple_with_scopes.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 import uvicorn
 from fastapi import FastAPI
 from starlette.authentication import requires
@@ -8,7 +8,7 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # The method you have to provide
-def verify_header(headers: List[str]) -> Tuple[List[str], FastAPIUser]:
+def verify_header(headers: Dict) -> Tuple[List[str], FastAPIUser]:
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)  # Usually you would decode the JWT here and verify its signature to extract the 'sub'
     scopes = ["admin"]  # You could for instance use the scopes provided in the JWT or request them by looking up the scopes with the 'sub' somewhere
     return scopes, user

--- a/fastapi_auth_middleware/middleware.py
+++ b/fastapi_auth_middleware/middleware.py
@@ -46,7 +46,7 @@ class FastAPIUser(BaseUser):
 class FastAPIAuthBackend(AuthenticationBackend):
     """ Auth Backend for FastAPI """
 
-    def __init__(self, verify_header: Callable[[str], Tuple[List[str], BaseUser]]):
+    def __init__(self, verify_header: Callable[[List[str]], Tuple[List[str], BaseUser]]):
         """ Auth Backend constructor. Part of an AuthenticationMiddleware as backend.
 
         Args:

--- a/fastapi_auth_middleware/middleware.py
+++ b/fastapi_auth_middleware/middleware.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Tuple, Callable, List
+from typing import Tuple, Callable, List, Dict
 
 from fastapi import FastAPI
 from starlette.authentication import AuthenticationBackend, AuthCredentials, AuthenticationError, BaseUser
@@ -46,7 +46,7 @@ class FastAPIUser(BaseUser):
 class FastAPIAuthBackend(AuthenticationBackend):
     """ Auth Backend for FastAPI """
 
-    def __init__(self, verify_header: Callable[[List[str]], Tuple[List[str], BaseUser]]):
+    def __init__(self, verify_header: Callable[[Dict], Tuple[List[str], BaseUser]]):
         """ Auth Backend constructor. Part of an AuthenticationMiddleware as backend.
 
         Args:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable, List, Dict
 
 from _pytest.fixtures import fixture
 from fastapi import FastAPI
@@ -11,7 +11,7 @@ from fastapi_auth_middleware import AuthMiddleware, FastAPIUser
 
 
 # Sample verification function, does nothing of effect
-def verify_header(headers: List[str]):
+def verify_header(headers: Dict):
     user = FastAPIUser(first_name="Code", last_name="Specialist", user_id=1)
     scopes = ["authenticated"]
     return scopes, user


### PR DESCRIPTION
Passing all headers instead of just the "Authorization" to the verification method in order to improve reusability and extensibility